### PR TITLE
Ignore compiler warnings for ambiguous crefs CS0419

### DIFF
--- a/NAntContrib.build
+++ b/NAntContrib.build
@@ -186,6 +186,8 @@
              output="${build.dir}/bin/${project.FormalName}.Tasks.dll"
              doc="${build.dir}/bin/${project.FormalName}.Tasks.xml">
             <nowarn>
+                <!-- do not report compiler warnings for ambiguous crefs until fixed in mono -->
+                <warning number="0419" if="${framework::get-family(framework::get-target-framework()) == 'mono'}" />
                 <!-- do not report warnings for missing XML comments -->
                 <warning number="1591" />
                 <!-- do not report deprecation warnings -->


### PR DESCRIPTION
Needed to get nantcontrib compiled with mono 2.10.x with warnaserror set.
