### PR TITLE
Remove # prefix from NUnit2Report anchor names

### DIFF
--- a/src/Tasks/NUnit2Report/xsl/NUnit-NoFrame.xsl
+++ b/src/Tasks/NUnit2Report/xsl/NUnit-NoFrame.xsl
@@ -316,7 +316,7 @@
         <xsl:for-each select="//test-suite[(child::results/test-case)]">
             <xsl:sort select="@name"/>
             <!-- create an anchor to this class name -->
-            <a name="#{generate-id(@name)}"></a>
+            <a name="{generate-id(@name)}"></a>
             <h3>TestSuite <xsl:value-of select="@name"/></h3>
 
             <table border="0" cellpadding="1" cellspacing="1" width="95%">


### PR DESCRIPTION
The NUnit2Report task generates &lt;a name="#..."> anchor names. This is invalid, as the href should contain the #, not the anchor name.

This bug causes Google Chrome to ignore the anchors when the link is clicked (except if you directly edit the URL in the browser address bar and add a second # character).

This pull request removes the errant #.
