### PR TITLE
Fix the NUnit2Report graphs so they work on modern browsers

### DIFF
--- a/src/Tasks/NUnit2Report/xsl/NUnit-NoFrame.xsl
+++ b/src/Tasks/NUnit2Report/xsl/NUnit-NoFrame.xsl
@@ -33,18 +33,24 @@
             span.covered {
                 background: #00df00; 
                 border:#9c9c9c 1px solid;
+                height: 1em;
+                display: inline-block;
             }
             span.uncovered {
                 background: #df0000; 
                 border-top:#9c9c9c 1px solid;
                 border-bottom:#9c9c9c 1px solid;
                 border-right:#9c9c9c 1px solid;
-                }
+                height: 1em;
+                display: inline-block;
+            }
             span.ignored {
                 background: #ffff00;
                 border-top:#9c9c9c 1px solid;
                 border-bottom:#9c9c9c 1px solid;
                 border-right:#9c9c9c 1px solid;
+                height: 1em;
+                display: inline-block;
             }
 
             td {


### PR DESCRIPTION
The graphs are generated by sizing HTML inline span elements - this works on IE, but fails on modern browsers.

Apologies I didn't spot this when I made the hash fragment fix - I had no idea there were supposed to be graphs!

![Before and After](http://img23.imageshack.us/img23/5619/nunit2report.png)
IE is IE7, Chrome is Chrome 21 Dev.
