### PR TITLE
Check for x86 and x64 paths to VB6.exe

### DIFF
--- a/src/Tasks/Vb6Task.cs
+++ b/src/Tasks/Vb6Task.cs
@@ -182,7 +182,9 @@ namespace NAnt.Contrib.Tasks {
                 } else {
                     try {
                         // check registry for VB6 install dir
-                        RegistryKey vbKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\VisualStudio\6.0\Setup\Microsoft Visual Basic");
+                        const string x86Vb6RegistryPath = @"SOFTWARE\Microsoft\VisualStudio\6.0\Setup\Microsoft Visual Basic";
+                        const string x64Vb6RegistryPath = @"SOFTWARE\Wow6432Node\Microsoft\VisualStudio\6.0\Setup\Microsoft Visual Basic";
+                        RegistryKey vbKey = Registry.LocalMachine.OpenSubKey(x86Vb6RegistryPath) ?? Registry.LocalMachine.OpenSubKey(x64Vb6RegistryPath);
                         if (vbKey != null) {
                             string productDir = vbKey.GetValue("ProductDir") as string;
                             if (productDir != null) {


### PR DESCRIPTION
Fix for [Issue #34](https://github.com/nant/nantcontrib/issues/34).